### PR TITLE
fix babel-plugin missing problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weex-loader",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "a webpack loader for weex",
   "main": "index.js",
   "author": "terrykingcha <terrykingcha@gmail.com>",

--- a/src/loader.js
+++ b/src/loader.js
@@ -29,11 +29,13 @@ const defaultLoaders = {
 
 function loadBabelModule (moduleName) {
   const currentModulePath = path.resolve(__dirname, '..', 'node_modules', moduleName)
+  const upLevelModulePath = path.resolve(__dirname, '..', '..', '..', 'node_modules', moduleName)
   const pwdModulePath = path.resolve(process.cwd(), 'node_modules', moduleName)
   if (fs.existsSync(currentModulePath)) {
     return currentModulePath
-  }
-  else if (fs.existsSync(pwdModulePath)) {
+  } else if (fs.existsSync(upLevelModulePath)) {
+    return upLevelModulePath
+  } else if (fs.existsSync(pwdModulePath)) {
     return pwdModulePath
   }
   return moduleName

--- a/src/loader.js
+++ b/src/loader.js
@@ -33,9 +33,11 @@ function loadBabelModule (moduleName) {
   const pwdModulePath = path.resolve(process.cwd(), 'node_modules', moduleName)
   if (fs.existsSync(currentModulePath)) {
     return currentModulePath
-  } else if (fs.existsSync(upLevelModulePath)) {
+  }
+  else if (fs.existsSync(upLevelModulePath)) {
     return upLevelModulePath
-  } else if (fs.existsSync(pwdModulePath)) {
+  }
+  else if (fs.existsSync(pwdModulePath)) {
     return pwdModulePath
   }
   return moduleName


### PR DESCRIPTION
fix a special case, npm install will store weex-loader dependence to uplevel/root package node_module
