### PR TITLE
update component name generate method

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -220,7 +220,7 @@ function loader (source) {
   const isElement = loaderQuery.element
   const isEntry = resourceQuery.entry
   const filename = path.relative('.', resourcePath)
-  const name = isEntry ? md5(filename) :
+  const name = isEntry ? md5(fs.readFileSync(filename)) :
                           (resourceQuery.name ||
                             getNameByPath(resourcePath))
 


### PR DESCRIPTION
In case weex page is composed by separate weex component jsbundles whose entry filename are `index.we`, which makes every bundle compiles as:

```
__weex_define__('@weex-component/f5e1c456d74a6374b2c0129d79c108e1', [], function(__weex_require__, __weex_exports__, __weex_module__) {
	
    __weex_script__(__weex_module__, __weex_exports__, __weex_require__)
    if (__weex_exports__.__esModule && __weex_exports__.default) {
        __weex_module__.exports = __weex_exports__.default
    }
	
    __weex_module__.exports.template = __weex_template__
	
     __weex_module__.exports.style = __weex_style__
	
})
	
__weex_bootstrap__('@weex-component/f5e1c456d74a6374b2c0129d79c108e1',undefined,undefined)
```

As shown above, `md5('index.we') === "f5e1c456d74a6374b2c0129d79c108e1"`.

So this commit suggests to generate component name based on file content instead of file name to avoid this problem.